### PR TITLE
Documentation and schema for API

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -4,10 +4,11 @@ from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include, path
 from rest_framework import routers
+from rest_framework.documentation import include_docs_urls
+from rest_framework.schemas import get_schema_view
 
 from quran.api import views as quran_views
 from recite.api import views as recite_views
-
 
 router = routers.SimpleRouter()
 router.register(
@@ -19,6 +20,8 @@ router.register(
     base_name="recitation")
 
 urlpatterns = [
+    path('docs/', include_docs_urls(title='Quran API Documentation')),
+    path('schema/', get_schema_view(title="Quran API schema")),
     path('admin/', admin.site.urls),
     url('api/', include((router.urls, 'api'), namespace='api')),
 ]

--- a/quran/api/views.py
+++ b/quran/api/views.py
@@ -5,7 +5,15 @@ from .serializers import SurahListSerializer, SurahDetailsSerializer
 
 
 class SurahListRetrieveView(viewsets.ReadOnlyModelViewSet):
-    """View that allows to list and retrieve Surah."""
+    """
+    Get method handler for list of Surahs.
+
+    retrieve:
+    Return the surah by given number.
+
+    list:
+    Return a list of all the surahs.
+    """
 
     lookup_field = 'number'
     queryset = Surah.objects.all()

--- a/recite/api/views.py
+++ b/recite/api/views.py
@@ -1,4 +1,6 @@
-from rest_framework import exceptions, status, viewsets
+import coreapi
+import coreschema
+from rest_framework import exceptions, mixins, schemas, status, viewsets
 
 from ..models import Recitation, Reciter
 from .serializers import RecitationSerializer, ReciterSerializer
@@ -12,15 +14,30 @@ class UnprocessableEntityError(exceptions.APIException):
 
 
 class ReciterListRetrieveView(viewsets.ReadOnlyModelViewSet):
-    """Get method handler for list of Reciters."""
+    """
+    Get method handler for list of Reciters.
+
+    retrieve:
+    Return the reciter by given id.
+
+    list:
+    Return a list of all the reciters.
+    """
 
     lookup_field = 'id'
     queryset = Reciter.objects.all()
     serializer_class = ReciterSerializer
 
 
-class RecitationListRetrieveView(viewsets.ReadOnlyModelViewSet):
-    """Get method handler for list of Recitations."""
+class RecitationListRetrieveView(
+        viewsets.GenericViewSet,
+        mixins.ListModelMixin):
+    """
+    Get method handler for list of Recitations.
+
+    list:
+    Return a list of the recitations for given reciter and given surah.
+    """
 
     serializer_class = RecitationSerializer
 
@@ -38,3 +55,27 @@ class RecitationListRetrieveView(viewsets.ReadOnlyModelViewSet):
         if recitations:
             return recitations
         raise exceptions.NotFound()
+
+    # Custom schema for core api documentation.
+    schema = schemas.AutoSchema(
+        manual_fields=[
+            coreapi.Field(
+                'reciter_id',
+                True,
+                "query",
+                coreschema.Integer(
+                    title='Reciter id',
+                    description='A unique integer value identifying reciter.',
+                ),
+            ),
+            coreapi.Field(
+                'surah_number',
+                True,
+                "query",
+                coreschema.Integer(
+                    title='Surah number',
+                    description='A unique integer value identifying surah.',
+                ),
+            ),
+        ]
+    )

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,5 @@
 Django>=2.1.5
 python-dotenv>=0.7.1
 django-rest-framework>=0.1.0
+coreapi>=2.3.3
+PyYAML>=3.13


### PR DESCRIPTION
Documentation of API endpoints.
Automatically generated code samples for each of the available API client libraries.
Support for API interaction.

Documentation uses self-documentation via CoreAPI from views and viewsets.
Schema is OpenAPI 3.0.0 using PyYAML.

**requirements updated**

The endpoints are:

[http://127.0.0.1:8000/docs/](http://127.0.0.1:8000/docs/)
[http://127.0.0.1:8000/schema/](http://127.0.0.1:8000/schema/)

Tested:
Basic django functions
Adding Reciter
