### PR TITLE
API returns segments as json subarray, not string.

### DIFF
--- a/django/recite/api/serializers.py
+++ b/django/recite/api/serializers.py
@@ -2,6 +2,11 @@ from rest_framework import serializers
 from recite.models import Recitation, Reciter
 
 
+class SegmentsListingField(serializers.RelatedField):
+    def to_representation(self, value):
+        return value
+
+
 class ReciterSerializer(serializers.ModelSerializer):
     """Serializer for Reciter model."""
 
@@ -16,6 +21,7 @@ class RecitationSerializer(serializers.ModelSerializer):
     # Send surah, ayah numbers instead of their pk
     ayah = serializers.IntegerField(source='ayah.number', read_only=True)
     surah = serializers.IntegerField(source='surah.number', read_only=True)
+    segments = SegmentsListingField(many=True, read_only=True)
 
     class Meta:
         model = Recitation


### PR DESCRIPTION
Should return `{"surah":1,"ayah":1,"segments":[[60,610],[620,1310],[1320,2450],[2460,5970]]}` instead of ``{"surah":1,"ayah":1,"segments":"[(60,610),(620,1310),(1320,2450),(2460,5970)]"}``